### PR TITLE
Update FAQs discord links to point to the same discord link as mor.org, resolves #112 

### DIFF
--- a/!KEYDOCS README FIRST!/FAQs.md
+++ b/!KEYDOCS README FIRST!/FAQs.md
@@ -43,8 +43,8 @@ At the moment, there are no such plans, but it's not ruled out in the future.
 Ethereum security and capital wise. Pool of stETH was found to be greatest on Arbitrum as well as cheap transaction costs which is vital for using MOR to pay for inference of AI models. 
 
 **How can I contribute?**  
-If you have any particular skills you'd like to offer please look to ⁠👥︱[dev-intros](https://discord.gg/AhuF3Nxc) or ⁠👥︱[designer-intros](https://discord.gg/TfAPbYGH).
-If your skills are outside of the scope of these two channels please put your skills down here ⁠🎣︱[skills](https://discord.gg/sqhs22PU)
+If you have any particular skills you'd like to offer please look to ⁠👥︱[dev-intros](https://discord.gg/Dc26EFb6JK) or ⁠👥︱[designer-intros](https://discord.gg/Dc26EFb6JK).
+If your skills are outside the scope of these two channels please put your skills down here ⁠🎣︱[skills](https://discord.gg/Dc26EFb6JK)
 
 **Who can I contact regarding cooperation/marketing proposals?**  
 You don't need anyone's permission to talk about Morpheus or add value as a Contributor. It's all built publicly.
@@ -126,10 +126,10 @@ There are Code Contributor Best Practices on [GitHub](hhttps://github.com/Morphe
 
 **How do I get in touch with other builders for collaborations?**  
 The Accelerator Corner is your go to
-⁠🤖︱[smart-agent-devs](https://discord.gg/by7hmJP9)
-⁠🦾︱[rag-devs](https://discord.gg/zjSgp4xw)
-⁠🎛︱[llm-fine-tunes](https://discord.gg/zFrtFy8V)
-⁠🖼︱[front-end](https://discord.gg/c9r6Y7E9)
+⁠🤖︱[smart-agent-devs](https://discord.gg/Dc26EFb6JK)
+⁠🦾︱[rag-devs](https://discord.gg/Dc26EFb6JK)
+⁠🎛︱[llm-fine-tunes](https://discord.gg/Dc26EFb6JK)
+⁠🖼︱[front-end](https://discord.gg/Dc26EFb6JK)
 
 **How do code providers get rewarded?**  
 They get emissions depending on their contributed weights vs the total amount of hours daily.
@@ -168,7 +168,7 @@ There are 4 of 7 multisig managed by core open source contributors. The address 
 It is locked for the first week (7 days) after deposit and you can withdraw any time after.
 
 **Is the MOR earned proportional to the amount of stETH deposited?**  
-Yes, MOR rewards for Capital start at 3,456 MOR per day and decrease from there over the 16 year emissions curve. This will be rebased to the Capital provider according to their contribution and the total TVL.
+Yes, MOR rewards for Capital start at 3,456 MOR per day and decrease from there over the 16-year emissions curve. This will be rebased to the Capital provider according to their contribution and the total TVL.
 
 **Do I lose earned MOR rewards if I decide to withdraw stETH?**  
 No, you don’t, but you will not earn rewards any longer as you are not the Capital Provider anymore.


### PR DESCRIPTION

 
# Fixes
-  Previously, in the [FAQs.md](https://github.com/MorpheusAIs/Docs/blob/main/!KEYDOCS%20README%20FIRST!/FAQs.md), discord links were specific  to individual channels, and all of them had expired, displaying **`invalid invite`** when clicked. This PR simplifies the invite management by linking to the same discord invite as [mor.org website](https://mor.org). 
    - If we still want to invite directly to a specific channel, new invites will need to be generated when links expire.
- Two minor grammar updates.

**Before**
![invite-invalid](https://github.com/MorpheusAIs/Docs/assets/414774/314ccd97-2d18-4922-b487-b5b59c690857)

**After**
![invite-success](https://github.com/MorpheusAIs/Docs/assets/414774/6b3227a9-0fe3-4975-b652-8735e5962128)

Resolves #112 
