### PR TITLE
Update Code Contributor Weights Guide.md

### DIFF
--- a/Guides/Code Contributor Weights Guide.md
+++ b/Guides/Code Contributor Weights Guide.md
@@ -3,13 +3,19 @@
 ## TL;DR
 The emissions for Code Contributors are calculated based on "weights". An individual's allocation is equal to the individual's weights divided up by the total number of weights times the daily MOR emissions. Morpheus is a marketplace for Code. Thus, Coders are competing to provide high quality code at the best price, and then maintain that code and their weight in the Code Contributors' rewards.
 
+## Introduction
+The weights system is designed to establish a structure that encourages participation by clarifying the process, setting clear expectations, rewarding past contributions, and explaining how to maintain weights. The overall goal of the system should aim to:
+
+1) Allocate weights in the way that maximizes value for Morpheus
+2) Fairly reward contributors based on the risk taken - higher risk earlier in project means higher weights
+3) Incentivize participants to contribute long term
+4) Simplify as much of the process as possible and design allocations in such a way to avoid foreseeable future complications.
+
 ## Weights Emissions Schedule & Supply Cap
-The weights earned by Coders are only valuable if they are scarce.  
-The number of Coder weights is capped at 100 Million weights, at the end of the Coder reward period (16 years).
+The weights earned by Coders are only valuable if they are scarce. The number of Coder weights is capped at 100 Million weights, at the end of the Coder reward period (16 years).
 
 ## Yearly Coding Weights
-- Year 1 / 50,000,000
-- Year 2 / 25,000,000
+- Year 1 + Year 2 / 75,000,000*
 - Year 3 / 12,500,000
 - Year 4 / 6,250,000
 - Year 5 / 3,125,000
@@ -28,13 +34,51 @@ The number of Coder weights is capped at 100 Million weights, at the end of the 
 
 This represents the MAX weights that can be earned in a period. It's the total buy signal in the Coding markeplace. Github maintainers of the 10 [Morpheus Reference Implementations](https://github.com/MorpheusAIs/Docs/blob/main/!KEYDOCS%20README%20FIRST!/Reference%20Implementations.md) should seek to get contributions for something less than this maximum number. And keep in mind if anyone fails to maintain their Code weights WILL be earned by others or returned to the Coding weight reserve.
 
+***Note**: To help Morpheus launch, there was an extremely large amount of effort required. Many of those efforts also preceded the establishment of the weights guide and thus the original contributors were retroactively given weights at varying $MOR implied prices for their efforts. This was done so at the rate at which efforts were provided to the GitHub maintainers and thus there was not an even distribution of weights month by month. The result of this is that as of the snapshot taking place on April 8, 2024 (which is the 7th month of Morpheus’ fiscal year), there were 48,390,420 total weights distributed. This means that adhering to a hard cap in year 1 would mean there are only 1,609,580 weights left for the subsequent five months, equivalent to 321,916 weights per month. Adhering to the Year 1 cap would result in such a small number of weights in the final months of the year, that it would likely deter new contributions. Therefore, the year 1 cap is being removed and merged into a single cap covering the first two years that is 75,000,000 weights. The total cap of 100,000,000 weights remains unchanged. 
+
+## Year 1 Weights Schedule
+Given the complexities surrounding the Year 1 value of weights, the weights schedule had more nuances than the future years. The following table provides the monthly weights schedule, including the weights distributed each month, the methodology used to determine the weights value, and ultimately the value of the weight at each snapshot. Additional details for each particular month can be found later in the guide where each snapshot is defined. Please note that October 2023 to March 2024 denote an average of monthly weights emitted since much of the early work got folded into the February and March snapshots.
+
+|Time | Weights Distributed | Cumulative Weights | Annual $MOR Emissions to Code | Total Weights | Annual $MOR Earned per Weight | $MOR Price Method | Implied $MOR Price | Weight Value | 
+|--- | --- | --- | --- | --- | --- | --- | --- | --- | 
+|Oct 2023 | 7,820,667 | 7,820,667 | n/a | n/a |n/a  | Cost Paid | $2.05 | $0.025 | 
+|Nov 2023 | 7,820,667 | 15,641,333 | n/a | n/a |n/a  | Cost Paid | $2.05 | $0.025 | 
+|Dec 2023 | 7,820,667 | 23,462,000 | n/a | n/a |n/a  | Cost Paid | $2.05 | $0.025 | 
+|Jan 2024 | 7,820,667 | 31,282,667 | n/a | n/a |n/a  | Cost Paid | $2.05 | $0.025 | 
+|Feb 2024 | 7,820,667 | 39,103,333 | n/a | n/a |n/a  | Cost Paid | $2.05 | $0.025 | 
+|March 2024 | 7,820,667 | 46,924,000 | n/a | n/a |n/a |  stETH Deposited | $6.89 | $0.200 | 
+|April 2024 | 4,536,232 | 51,460,232 | 1,222,076 | 100,000,000 | 0.01222 | MRC09 Opening Price | $33.33 | $0.407 | 
+|May 2024 | 2,500,000 | 53,960,232 | 1,222,076 | 100,000,000 | 0.01222 | MRC09 + Liquidity Support stETH | $64.10 | $0.783 | 
+|June 2024 | 2,250,000 | 56,210,232 | 1,222,076 | 100,000,000 | 0.01222 | Live Trading Price | TBD | TBD | 
+|July 2024 | 2,000,000 | 58,210,232 | 1,222,076 | 100,000,000 | 0.01222 | Live Trading Price | TBD | TBD | 
+|Aug 2024 | 1,750,000 | 59,960,232 | 1,222,076 | 100,000,000 | 0.01222 | Live Trading Price | TBD | TBD | 
+|Sept 2024 | 1,500,000 | 61,460,232 | 1,222,076 | 100,000,000 | 0.01222 | Live Trading Price | TBD | TBD | 
+
 ## Monthly Weights Schedule
 These weights will be divided into even monthly amounts starting in Year 2 (September 2nd 2024).  
-For example with 25,000,000 weights available the 2nd year, divided by 12 months, the amount of weights available months 13 to 24 will be 2,083,333 each month.
+
+The following table outlines the Year 2 and beyond weights schedule:
+
+|Year | Annual Weights Distributed | Monthly Weights Distributed | Cumulative Weights | Annual $MOR Emissions to Code | Total Weights | Annual $MOR Earned per Weight | $MOR Price Method | Implied $MOR Price | Weight Value | 
+|--- | --- | --- | --- | --- | --- | --- | --- | --- |---| 
+|2 |13,539,768 | 1,128,314 | 75,000,000 | 1,143,133 | 100,000,000 | 0.01143 | Live Trading Price | TBD | TBD | 
+|3 |12,500,000 | 1,041,667 | 87,500,000 | 1,064,189 | 100,000,000 | 0.01064 | Live Trading Price | TBD | TBD | 
+|4 |6,250,000 | 520,833 | 93,750,000 | 985,245 | 100,000,000 | 0.00985 | Live Trading Price | TBD | TBD | 
+|5 |3,125,000 | 260,417 | 96,875,000 | 906,302 | 100,000,000 | 0.00906 | Live Trading Price | TBD | TBD | 
+|6 |1,562,500 | 130,208 | 98,437,500 | 827,358 | 100,000,000 | 0.00827 | Live Trading Price | TBD | TBD | 
+|7 |781,250 | 65,104 | 99,218,750 | 748,415 | 100,000,000 | 0.00748 | Live Trading Price | TBD | TBD | 
+|8 |390,625 | 32,552 | 99,609,375 | 669,471 | 100,000,000 | 0.00669 | Live Trading Price | TBD | TBD | 
+|9 |195,313 | 16,276 | 99,804,688 | 590,527 | 100,000,000 | 0.00591 | Live Trading Price | TBD | TBD | 
+|10 |97,656 | 8,138 | 99,902,344 | 511,584 | 100,000,000 | 0.00512 | Live Trading Price | TBD | TBD | 
+|11 |48,828 | 4,069 | 99,951,172 | 432,640 | 100,000,000 | 0.00433 | Live Trading Price | TBD | TBD | 
+|12 |24,414 | 2,035 | 99,975,586 | 353,696 | 100,000,000 | 0.00354 | Live Trading Price | TBD | TBD | 
+|13 |12,207 | 1,017 | 99,987,793 | 274,753 | 100,000,000 | 0.00275 | Live Trading Price | TBD | TBD | 
+|14 |6,104 | 509 | 99,993,897 | 195,809 | 100,000,000 | 0.00196 | Live Trading Price | TBD | TBD | 
+|15 |3,052 | 254 | 99,996,949 | 116,865 | 100,000,000 | 0.00117 | Live Trading Price | TBD | TBD | 
+|16 |1,526 | 127 | 99,998,475 | 37,937 | 100,000,000 | 0.00038 | Live Trading Price | TBD | TBD | 
 
 ## Bitcoin Halving Schedule As The Basis For This Code Weight Halving Model
-Rewards in real terms have grown, even as weights decline over time.  
-Lets run through the numbers below as an example.  
+Rewards in real terms have grown, even as weights decline over time.  Let's run through the numbers below as an example.  
 
 From September 2nd 2023 to February 8th 2024, developers contributed to the Morpheus open source with very little knowledge of what the implied value of weights or MOR would be (if not zero). 2000 weights $0.025 USD each ($50) was a rule of thumb just based on what the average developer cost per hour is globally. So say ~ 43,000,000 weights were earned during this 5 month and 6 day period (5.2 months). That's 8,269,230 weights per month times $0.025 implies a value equal to $206,730 USD worth per month total (spread over dozens of Code Contributors).
 
@@ -50,18 +94,23 @@ The proposed schedule is 1 year halving for Morpheus coding weights which fits t
 No one knows how much MOR will be worth in ETH or USD or any other currency. 1 MOR = 1 MOR**
 
 **Implied weight value formula is:**
-- One. Total MOR emissions for Coding per day (started at 3,456).
+- One. Total MOR emissions for Coding per relevant year.
 - Two. Divide by 100,000,000 (total weights) 
-- Three. Equals pro-rata of MOR earned by 1 weight per day = 0.00003456 MOR per day.
-- Four. Times 365 days for 12 months of MOR emissions for that weight = 0.0126 MOR per year
-- Five. Times the current implied MOR price (for example $100 USD on secondary markets) = $1.26 per weight.
+- Three. Equals pro-rata of MOR earned by 1 weight per year.
+- Four. Times the current implied MOR price
 
-So in this example: $1.26 USD implied value of MOR earned by 1 weight over 12 months via MOR emissions. This calculation is applied across the average of the data points for the month. When MOR has a free floating market price on May 8th 2024 and beyond then that MOR price can be used to inform the MOR token price part of the formula.
+**Example**
+- One. Year 1 emissions = 1,222,076 $MOR
+- Two. Divide by 100,000,000 (total weights) 
+- Three. Equals pro-rata of MOR earned by 1 weight per year = equals 0.01222 $MOR per weight
+- Four. Times the current implied MOR price. If $MOR is $100, this would be $1.222 USD per weight.
+
+The result in step four is the implied value of MOR earned by 1 weight over 12 months via MOR emissions. This calculation is applied across the average of the data points for the month. When MOR has a free floating market price on May 8th 2024 and beyond then that MOR price can be used to inform the MOR token price part of the formula.
 
 This is calculation is in some ways conservative. The MOR rewards keep going for 16 years. But this implied value discounts future emissions and also makes the base assumption the Contribution is maintained for at least 1 year. If a weight is maintained for longer of course the holder would gain additional MOR beyond this estimate or if the weight is not maintained for at least 1 year the holder would gain less MOR than this estimate. And of course the future MOR price is unknown and so the holder takes the risk it could be $0. 
 
 **So keep this in mind if you are bidding on Code work. 
-If you are asking for 1,000 weights, you are saying the Code is in theory worth $1,260 USD worth of MOR.**
+If you are asking for 1,000 weights, you are saying the Code is in theory worth $1,220 USD worth of MOR.**
 
 ## New Coding Weights
 > [!NOTE]
@@ -90,6 +139,16 @@ But, this high reward will also generate a lot of competition among Coders.
 It is important to understand that the implied value is decided by the market. The amount of stETH deposited creates a certain amount of yield that in turns buys up MOR from the AMM.  
 This Protocol Owned Liquidity increases the scarcity of MOR and provides liquidity for Coders, Compute Providers and Community Front End developers.
 
+## Snapshot Summary Table
+The table below repsents a summary of the data for each snapshot. Additional information can be found in the subsections below each particular snapshot.
+
+|Snapshot Period | Methodology | Implied $MOR Price | USD per Weight | 
+|--- | --- | --- | --- |
+| Oct 2023 to Feb 2024 | Cost Paid | $2.05 | $0.025 |
+| Feb 2024 to March 2024 | stETH Deposited | $6.89 | $0.20 |
+| March 2024 to April 2024 | MRC09 Opening Price | $33.33 | $0.407 |
+| April 2024 to May 2024 | MRC09 Opening Price + Liquidity Support stETH | $64.10 | $0.783 |
+
 ## September 2nd 2023 to February 8th 2024 Implied Value of a Weight "Snapshot 1" = $0.025 USD per Weight
 In theory, the initial implied value of 1 weight was $0.025 USD before there was a market-determined price as that is the average real cost paid to auditors & developers sponsored by Morpheus community members. However now that there is a real-world implied value of 1 weight this ought to be considered in each monthly snapshot.
 
@@ -101,19 +160,23 @@ At 88,000 deposited stETH annually providing 2,904 stETH in yield balanced again
 This is calculated by taking the number of MOR earned by all Coders the first year (1,222,076 MOR) and dividing by 42,000,000 which equals 0.029 MOR per weight. 
 In theory this results in, $6.89 USD per MOR that equals $0.20 in USD terms.
 
-## March 8th to April 8th 2024 Implied Value of a Weight "Snapshot 3" = $1.26 USD per Weight
+## March 8th to April 8th 2024 Implied Value of a Weight "Snapshot 3" = $0.407 USD per Weight
 > [!NOTE]
 > **The following is all theory, presented as an example for how one could arrive at their own estimate. 
 No one knows how much MOR will be worth in ETH or USD or any other currency. 1 MOR = 1 MOR**
 
-The implied price for snapshot 3 is estimated based the implied value set in the secondary market for MOR tokens.
-At the moment of the snapshot secondary markets for MOR are trading at between $100 to $200 USD per MOR. By multiplying the number of MOR per day ~ 3,456 (for Coding Rewards) by 365, and then multiply that by the $100 USD price per MOR, we get the total Coder rewards for 1 year and divide by 100,000,000 we get the per weight implied theoretical price of $1.26 USD per weight.
+The implied price for snapshot 3 is estimated based on methodology as defined by MRC09, which establishes the opening price for $MOR trading. This approach aligns the estimation for price across all aspects of Morpheus and uses a consistent calculation. This methodology pairs 52% of the stETH yield generated by capital providers with the 50,310 $MOR from the Protection Fund. As of the snapshot date, this utilizes an average of 115,000 stETH deposited, $3,500 ETH and a 3.25% yield on Lido stETH. The result is a $MOR price of $33.33 which equates to $0.407 per weight. 
 
-**All told this implies a current value of each weight at $1.26 USD.**
+**All told this implies a current value of each weight at $0.407 USD.**
 
+**Please note, this will require a one-time adjustment to the original weights in this snapshot. All contributors for the March 8th to April 8th snapshot will see their contributions multiplied by 3.09582 in the next Smart Contract update on May 8th. This was calculated by applying the $0.407 value per weight as described above instead of the original $1.26 value per weight based on secondary markets. It was deteremined that the secondary markets have too low of volume and too thin of order books that they could be subject to manipulation and are not the most reliable source of estimated pricing**
+
+## April 8th to May 8th 2024 Implied Value of a Weight "Snapshot 4" = $0.783 USD per Weight
 > [!NOTE]
 > **The following is all theory, presented as an example for how one could arrive at their own estimate. 
 No one knows how much MOR will be worth in ETH or USD or any other currency. 1 MOR = 1 MOR**
+
+April 8th to May 8th - The implied price for snapshot 4 is estimated based methodology as defined by MRC09, which establishes the opening price for $MOR trading. The one variation between May 8th valuation and April 8th valuation is that the May 8th valuation accounts for 100% of the stETH yield instead of 52%. The reason for this is that the remaining 48% is included as part of the Liquidity Support Range which can be utilized by the AMM as needed. Please see MRC09 for additional details. To provide transparency and consistency for all Code providers, this price will be based on trailing monthly averages for inputs, resulting in $64.10 per $MOR which equates to $0.783 per weight.
 
 See the Morstats.info website page where you can run these estimates dynamically.  
 https://morstats.info/code-weights/


### PR DESCRIPTION
Updated guide to add new tables and details. These include defining the implied price methodology for April 8 and May 8 snapshots (pre-live trading), as well as update the weight emission schedules as noted in MRC31 which removes the Year 1 cap and spreads the remaining weights across Year 1 + Year 2