### PR TITLE
Create Weight Maintenance Guide.md

### DIFF
--- a/Guides/Weight Maintenance Guide.md
+++ b/Guides/Weight Maintenance Guide.md
@@ -1,0 +1,44 @@
+# Weight Maintenance Guide (Part of MRC31)
+
+
+**Introduction:** The GitHub repository maintainer rewards contributions with weights, a crucial component of the protocol development. Weights play a pivotal role in motivating ongoing development and collaboration, serving as an incentive mechanism that underpins the operational expansion of the protocol.
+
+The weight system ensures that contributions are not only recognized when developed but also maintained over time, providing a sustainable framework for growth and enhancement. It's essential for all participants in the past, present, and future to fully understand how this system works and how they can actively maintain their weights. This guide provides a comprehensive overview of the weight maintenance process, outlining clear steps to support the continued expansion and development of Morpheus.
+
+## **Weight Acceptance and Maintenance**
+
+When a contribution is accepted by a GitHub repository maintainer, this not only acknowledges the value of the contribution but also initiates the incorporation of that work into the larger project framework. Acceptance of a contribution results in the assignment of weights to the contributor. These weights act as a tangible acknowledgment of the contributor's effort and expertise.
+
+Maintaining these weights, however, requires more than just an initial contribution. It involves a commitment to ongoing development and enhancement of the work contributed. This maintenance is crucial because it ensures that the contribution continues to meet the evolving needs of the project and remains compatible with other parts of the system.
+
+If a contribution is neglected, the assigned weights are at risk of being revoked. This mechanism is in place to encourage contributors to stay engaged with the project and to ensure that their contributions continue to serve their purpose. In the event that the original contributor is unable or unwilling to maintain their contribution, the weights can be revoked, and the scope of work is open for another participant to take on the responsibility of updating and maintaining. This not only keeps the project moving forward but also ensures a fair and meritocratic system where ongoing effort is rewarded.
+
+Please note, there are some weights that by nature won’t require much maintenance going forward. Many of these weights are foundational in the start-up and development of the Morpheus ecosystem - providing contributions that Morpheus could not have moved forward without. Therefore, contributions will not be removed simply because there isn’t maintenance to be completed. Weights are only moved to at-risk if maintenance is required and the maintenance is either not completed or if the efforts are unsatisfactory.
+
+## **At-Risk Process & Grace Period**
+
+The GitHub repository maintainer is tasked with monitoring contributions to determine when maintenance, updates, or further work is needed. Each month, during the snapshot, the repo maintainer updates a markdown file that specifies the original snapshot when the weights were awarded, the MRI the contribution relates to, the scope of work requiring attention, the maintenance required, the associated weights, the contributor’s handle (if available), and the corresponding Ethereum address.
+
+The publishing of the markdown file serves as the official notice being served to contributors that their weights have moved to at-risk.
+
+|Original Snapshot | MRI Grouping | Scope of Contribution | Maintenance Required| Weights| Handle| Address|
+|--- | ---| --- | ---| ---| ---| ---|
+|Snapshot 1| Protection Fund | Update x translation| Translation ties to March 8th file, needs to be updated for July 15th revisions | 10 | @Community1 | 0x…|
+|Snapshot 1| Smart Contracts| Update x Smart Contract| Smart contract no longer works with Morpheus 0.0.9 update. Need to make contract functional with latest version | 20 | @Community2 | 0x…|
+|Snapshot 2| Interoperability| Refactor API | API broken - need to update to make functional | 30 | @Community3 | 0x…|
+
+
+Once added to the list, it begins the grace period which extends for one month following each snapshot. During this time, contributors must either:
+1) Complete the necessary work to satisfy the grace period description, and submit their pull request.
+2) Contact the repository maintainer to discuss and agree upon a reasonable timeframe for completing the updates, if they are unable to meet the deadline.
+
+Failure to update or communicate effectively by the end of the grace period may result in the removal of weights. Subsequently, the scope of work will become available for new participants who can earn weights by taking over and successfully maintaining the contribution.
+
+## **Urgent Updates **
+
+This document outlines the standard procedures to be followed in the ordinary course of development. As Morpheus is a fast evolving ecosystem, there will occasionally be situations that arise that require urgent updates. These could arise when there are errors identified, bug fixes, etc. In these types of one-off situations requiring urgent action, the GitHub Maintainer reserves the right to change, update, fix, or otherwise change any and all code as needed. These types of situations will not follow the standard operating procedures, but will be handled in the manner best needed for Morpheus.  
+
+## **Conclusion**
+
+This guide provides a clear and structured framework for the maintenance of weights within each relevant GitHub repository, underlining the commitment to transparency and fairness in recognizing and rewarding contributions. By adhering to this guide, contributors can ensure that their efforts are not only acknowledged but also preserved over time. This system guarantees that the valuable work done today continues to provide benefits well into the future, fostering a collaborative and dynamic environment. Contributors should remain proactive in maintaining their work to retain their weights and uphold the integrity and effectiveness of the protocol.
+


### PR DESCRIPTION
Publishing Weights Maintenance Guide as part of MRC31 deliverables. This guide documents the process by which weights that have been distributed can be revoked from a contributor when they fail to keep up with their duties of maintaining the effort.