### PR TITLE
Add morcodes MRI weight analysis contribution snapshot 5

### DIFF
--- a/Contributions/Code - Proof_Of_ContributionSnapshot5.md
+++ b/Contributions/Code - Proof_Of_ContributionSnapshot5.md
@@ -95,3 +95,4 @@ Please include the "pipe" `|` symbol correctly as seen above so your contributio
  **Snapshot** | **MRI** | **Wallet Address** | **GitHub Handle** | **Description of Contribution** |  **Proof of Contribution** | **Weights Requested**  
 ---|---|---|---|---|---|---
  5 | 3 |0xf93de9fb07f5762a1e3db9a5c687595111928d77 | mordeveloper | Description of Contribution | Proof of contribution links | 1250 | 
+ 5 | 8 |0x80AC5d6B29EC148cb1f71a18C2A4F0A0c7DEddF0 | mor-codes | MRI Weight Analysis (Overall & By Snapshot) | https://colab.research.google.com/drive/1v6DvKvcTDDt5IdWGNaSNURyUjPFdc5bZ?usp=sharing | 15000 | 


### PR DESCRIPTION
# MRI Weight Analysis by Mor.Codes

Source code is available on Google Colab: https://colab.research.google.com/drive/1v6DvKvcTDDt5IdWGNaSNURyUjPFdc5bZ?usp=sharing

## Overall MRI weight analysis without secondary MRI

![image](https://github.com/MorpheusAIs/Docs/assets/168667546/acf8a9d0-a554-4b84-89c5-951ce3379f8b)

The overall MRI weight shows that MRI 1 is clearly dominant, with MRI 3 and MRI 7 as runners-up. Here are the details:
* MRI 1: Smart Contracts on Ethereum / Arbitrum
* MRI 3: Morpheus Local Install Desktop / Mobile
* MRI 7: Compute Proofs Morpheus / Lumerin

It makes sense that MRI 1 is dominant since smart contracts on Ethereum / Arbitrum were developed in the first phase when the implied value was extremely low.

Interestingly, most records for MRI 1 are from snapshot 1, with a similar description: "Anon Contribution to papers, reviews, and code."

## Overall MRI weight analysis with secondary MRI

![image](https://github.com/MorpheusAIs/Docs/assets/168667546/b927a8b3-b7e5-4696-ad73-3805453e9600)

In the MRI weight analysis without considering secondary MRI, MRI 1 is clearly dominant over the others. However, when secondary MRI is taken into account, MRI 1 loses its dominance, and MRI 6 and MRI 10 gain significant weight from the secondary MRI of MRI 1 submissions.

## Per snapshot MRI weight analysis

![image](https://github.com/MorpheusAIs/Docs/assets/168667546/e9f188ea-6071-4a6c-8f1d-2d42607d74a3)

In the overall MRI weight distribution, we see that MRI 1, 3, and 7 are the dominant MRIs. However, a closer look at each snapshot reveals an interesting evolution. MRI 1 is only dominant in snapshot 1 (Without Secondary MRI) but rarely gains weight in subsequent snapshots. MRI 3 ceases to be dominant after snapshot 2, while MRI 7 continues to be dominant.

Here is an overview of the dominant MRI on each snapshot
* Snapshot 1: Whitepaper and Smart Contract Development
    * No obvious dominance MRI
* Snapshot 2: Token Fair Launch and Capital Providing
    * MRI 3: Morpheus Local Install Desktop / Mobile
    * MRI 4: TCM / MOR20 Token Standard for Fair Launches
    * MRI 7: Compute Proofs Morpheus / Lumerin
* Snapshot 3: Smart Agent Development
    * MRI 2: Smart Agents Tools & Examples
    * MRI 7: Compute Proofs Morpheus / Lumerin
* Snapshot 4: Finding New Capital Beyond stETH
    * MRI 6: Capital Proofs Extended beyond Lido stETH
    * MRI 7: Compute Proofs Morpheus / Lumerin
    * MRI 2: Smart Agents Tools & Examples
    * MRI 4: TCM / MOR20 Token Standard for Fair Launches

Interestingly, the dominant MRI changes to fit the development needs in each snapshot.

In snapshot 4, MRI 6 is dominated by an outlier with the description "4Project Integrations | GenLayer | Mor20 | Pool Creation/Strategy," earning 425,000 Weight ($332,775 Implied).

## Per snapshot average MRI weight analysis

![image](https://github.com/MorpheusAIs/Docs/assets/168667546/4596ca2d-fe34-4c6b-8e18-0970382c69be)

In addition to the total weight analysis, the average weight analysis highlights the MRIs that yield the highest reward rates for each snapshot. Interestingly, MRI 8 (Code Proofs & Dashboards) leads in snapshot 1, while MRI 7 (Compute Proofs Morpheus / Lumerin) leads in all subsequent snapshots and is expected to continue leading until Lumerin is deployed in production.

MRI 8 leads snapshot 1 due to an outlier. Similarly, MRI 10 has outliers, making this metric less effective for snapshot 1.

Subsequent snapshots are led by MRI 7 (Lumerin), usually submitted by a few contributors with exceptionally high weight.

Contributing to Lumerin development yields the highest rewards among all contributions in the Morpheus ecosystem.
