### PR TITLE
Clarify that Appendix A scope is address and chain

### DIFF
--- a/Security Audit Reports/Bug Bounty Program.md
+++ b/Security Audit Reports/Bug Bounty Program.md
@@ -198,6 +198,8 @@ When you work with us under this program, you can expect us to:
 
 **Last updated: 2026-08-07.** All addresses below were read from chain on that date. Report against the address in the "Address" column; where that address is a proxy or a diamond, its current implementation or facet code is in scope through it.
 
+**Scope is address _and_ chain.** Several in-scope addresses are deterministic deployment twins: the same address hosts a different contract on a different chain. For example `0xE30279b79392AEfF7fDf1883C23d52eBA9D88A75` is the ProviderRegistry facet on Base and the RewardPool implementation on Ethereum Mainnet. Pin the chain as well as the address, and state both in your report.
+
 ### Ethereum Mainnet — Capital
 
 | Contract | Address | Type |


### PR DESCRIPTION
Appendix A defines scope by deployed address. Several of the listed addresses are deterministic deployment twins — the same address hosts a different contract on a different chain — so an address alone does not identify a target.

Verified on chain 2026-08-10:

| Address | Ethereum Mainnet | Base | Arbitrum One |
|---|---|---|---|
| `0xb7994dE339AEe515C9b2792831CD83f3C9D8df87` | ERC1967Proxy → RewardPool | ModelRegistry facet | — |
| `0x47176B2Af9885dC6C4575d4eFd63895f7Aaa4790` | ERC1967Proxy → DepositPool | — | ERC1967Proxy → L2TokenReceiverV2 |
| `0xE30279b79392AEfF7fDf1883C23d52eBA9D88A75` | RewardPool implementation | ProviderRegistry facet | — |

The third is the one Appendix A does not currently disambiguate: it is listed only as the Base ProviderRegistry facet, while the same address is the RewardPool implementation on Ethereum. Since §1.1 puts implementation and facet code in scope through the listed address, a researcher who pins the wrong chain can land on a live contract that is out of scope for the target they intended, and the report is then closed under §4 step 1 without recourse.

Adds one paragraph to the Appendix A header. No change to what is in scope.