### PR TITLE
docs: Incidents folder + SessionRouter stipend leak — @DavidAJohnston to approve

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ After connecting Morpheus with your web3 wallet, you can test the **Data Smart A
 - [Morpheus Multisig Account](https://github.com/MorpheusAIs/Docs/blob/main/!KEYDOCS%20README%20FIRST!/Morpheus%20Multisignature%20Account.md)
 - [Protection Fund Details](https://github.com/MorpheusAIs/Docs/blob/main/!KEYDOCS%20README%20FIRST!/Protection%20Fund%20Details.md)
 - [Bug Bounty Program](https://github.com/MorpheusAIs/Docs/blob/main/Security%20Audit%20Reports/Bug%20Bounty%20Program.md)
+- [Incidents](https://github.com/MorpheusAIs/Docs/tree/main/Security%20Audit%20Reports/Incidents)
 - [Morpheus Meetup Guide](https://github.com/MorpheusAIs/Docs/blob/main/!KEYDOCS%20README%20FIRST!/FAQs%20%26%20Guides/Guides/Morpheus%20Meetup%20Guide.md)
 
 ---

--- a/Security Audit Reports/Incidents/README.md
+++ b/Security Audit Reports/Incidents/README.md
@@ -1,0 +1,5 @@
+# Incidents
+
+Protection Fund incident records. One file per patched finding that is proposed or paid as a bounty.
+
+See [Protection Fund Details](../../!KEYDOCS%20README%20FIRST!/Protection%20Fund%20Details.md) and the [Bug Bounty Program](../Bug%20Bounty%20Program.md).

--- a/Security Audit Reports/Incidents/SessionRouter Stipend Leak.md
+++ b/Security Audit Reports/Incidents/SessionRouter Stipend Leak.md
@@ -1,0 +1,99 @@
+# SessionRouter stipend leak — intra-day stake recycle
+
+**Status:** Patched on BASE mainnet (2026-07-31). This file is the Protection Fund incident record for a bounty. It is not a request for a new fix.
+
+**Proposal:** review for accuracy, then merge.
+
+## Summary
+
+`SessionRouter._rewardUserAfterClose` treated a **late close** (`closedAt >= endsAt`) as a full immediate refund of the consumer stake. A session that expired and was then closed returned the used stipend in the same transaction. The same MOR could open another session in the same UTC day and draw stipend again.
+
+That is the stipend leak / intra-day recycle. It is a compute-contract bug. It is in scope for the Protection Fund (bug disclosed against a live Morpheus compute contract) and for Bug Bounty Program v2 (deployed bytecode, measurable over-issuance of rewards).
+
+## Target
+
+| Field | Value |
+|---|---|
+| Contract | SessionRouter facet, reached through the Inference Diamond |
+| Chain | Base mainnet |
+| Diamond | `0x6aBE1d282f72B474E54527D93b979A4f64d3030a` |
+| Owner (cut) | Gnosis Safe 5-of-9 `0x1FE04BC15Cf2c5A2d41a0b3a96725596676eBa1E` |
+| Invariant that broke | Used consumer stake cannot be recycled inside the same UTC day to draw another stipend against the same MOR |
+| Preconditions | Anyone who can open a funded session. No admin key. Gas is the only friction. |
+
+## Attack (as the shipped docs now name it)
+
+1. Open a funded session.
+2. Let it expire (`endsAt` pass).
+3. Call `closeSession` after `endsAt` (the consumer node does this ~1 minute later).
+4. Pre-fix: full stake returned in that tx. Open another session the same day. Repeat.
+
+Post-fix: unused stake still returns on close. **Used stipend day-locks** until the next UTC day (`userStakesOnHold`, claim via `withdrawUserStakes`). Anchor is `min(closedAt, endsAt)`, not the close-tx timestamp.
+
+## Fix that already shipped
+
+Behavior change in `_rewardUserAfterClose` ([#833](https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/pull/833), from [@rcondron](https://github.com/rcondron) [#830](https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/pull/830)):
+
+```solidity
+uint128 sessionEnd_ = uint128(session.closedAt.min(session.endsAt));
+uint128 startOfEndDay_ = startOfTheDay(sessionEnd_);
+uint128 releaseAt_ = startOfEndDay_ + 1 days;
+
+if (block.timestamp < releaseAt_) {
+    // lock used stipend in userStakesOnHold
+}
+```
+
+| Step | PR | Merged |
+|---|---|---|
+| Original patch | [#830](https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/pull/830) [@rcondron](https://github.com/rcondron) (superseded — wrong base) | closed 2026-07-30 |
+| Contract + tests + runbook + nodedocs | [#833](https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/pull/833) `0x18f6…6b9C` → `dev` | 2026-07-29 |
+| Promote | [#834](https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/pull/834) `0x18f6…6b9C` `dev`→`test` | 2026-07-29 |
+| Promote | [#835](https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/pull/835) `0x18f6…6b9C` `test`→`main` | 2026-07-29 |
+| Deploy note | [@nomadicrogue](https://github.com/nomadicrogue) on #830: contract update instructions sent for testnet and mainnet | 2026-07-30 |
+| Mainnet `diamondCut` | runbook two-step: EOA deploys facet, Safe signs one cut | 2026-07-31 |
+
+Docs already state the new rule: *“You can reuse the same MOR many times in one day by letting sessions expire”* is false after the day-lock.
+
+## Impact
+
+While the hole was open, network-wide extraction was bounded by the compute treasury’s **~1% daily draw**, about **25,000 MOR/day**, declining as the treasury shrank. The recycle was unbounded *per stake*; the daily draw was the ceiling on damage.
+
+This is **over-issuance of compute stipend** from the protocol funding account, not a lock of user deposits and not a capital-pool drain. Bug Bounty v2 maps “measurable over-issuance of rewards” to **High ($10,000–$50,000)**. The assessed award is inside that band.
+
+## Submitter
+
+`0x18f61d9C2b3303d2C6cEafBEF81302c1016C6b9C` (`0x18f6…6b9C`)
+
+First valid report on this unique issue. Under Bug Bounty Program v2, the first address to submit a valid report is the only one eligible. Patch authors listed above are not additional bounty claimants.
+
+## Protection Fund payment requested
+
+| Field | Value |
+|---|---|
+| Type | Pre-defined Protection Fund payment #1 — bug discovered and disclosed |
+| Program | [Bug Bounty Program v2](../Bug%20Bounty%20Program.md) (effective 2026-08-07); [Protection Fund Details](../../!KEYDOCS%20README%20FIRST!/Protection%20Fund%20Details.md) |
+| Submitter / payee | `0x18f61d9C2b3303d2C6cEafBEF81302c1016C6b9C` |
+| Amount | **$15,000 USD** |
+| Asset | **USDC** |
+| Schedule | **5 monthly payments of $3,000 USDC** |
+| Paid by (on behalf of the Protection Fund) | `0x65485DEECeAF608C8304978CA0FCA1C49f5308aE` |
+| Paid to | `0x18f61d9C2b3303d2C6cEafBEF81302c1016C6b9C` |
+
+Code Providers: signal TRUE/FALSE on this record within 7 days of merge. If a majority of participating weight validates TRUE, authorize the schedule above. Each monthly transfer is recorded on this file (or as a PR comment) by tx hash.
+
+## What this record is not
+
+- Not [SmartContracts #63](https://github.com/MorpheusAIs/SmartContracts/issues/63) / [#64](https://github.com/MorpheusAIs/SmartContracts/issues/64) ([@Apollyon13X](https://github.com/Apollyon13X)).
+- Not a user-error reimbursement.
+- Not a request to revert or re-cut SessionRouter.
+
+## Sources
+
+- https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/pull/830
+- https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/pull/833
+- https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/pull/834
+- https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/pull/835
+- https://github.com/MorpheusAIs/Morpheus-Lumerin-Node/blob/main/smart-contracts/docs/session-day-lock-upgrade-runbook.md
+- [Protection Fund Details](../../!KEYDOCS%20README%20FIRST!/Protection%20Fund%20Details.md)
+- [Bug Bounty Program](../Bug%20Bounty%20Program.md)


### PR DESCRIPTION
## Approval

**@DavidAJohnston — please review for accuracy and approve this PR if the record is correct.**

Merge after that approval. Merge files the incident record only; it does not send USDC.

## What this is

- Patched compute-contract finding (SessionRouter intra-day stipend recycle). Fix already shipped: Morpheus-Lumerin-Node #830 → #833 → #835; mainnet cut 2026-07-31.
- Protection Fund payment #1 (bug disclosed). Bug Bounty v2 High band.
- Submitter / payee is the reporting address only. No personal names.

## Payment (as written in the record)

| | |
|---|---|
| Amount | $15,000 USDC |
| Schedule | 5 × $3,000 |
| Paid by (on behalf of the Protection Fund) | `0x65485DEECeAF608C8304978CA0FCA1C49f5308aE` |
| Paid to (submitter) | `0x18f61d9C2b3303d2C6cEafBEF81302c1016C6b9C` |

## Files

- `Security Audit Reports/Incidents/README.md`
- `Security Audit Reports/Incidents/SessionRouter Stipend Leak.md`
- `README.md` — link to Incidents